### PR TITLE
Add OAuth2 'password 'authentication grant type

### DIFF
--- a/en/Devel/API/V1/Authentication.rst
+++ b/en/Devel/API/V1/Authentication.rst
@@ -30,9 +30,9 @@ Supported Authorization Response Type
   * token
   * code_and_token
 
-  At this time we do not expire OAuth access tokens, you should be prepared for
-  this possibility in the future. Also remember that a user may revoke access
-  via the Phraseanet settings page at any time.
+.. note:: At this time we do not expire OAuth access tokens, you should be prepared for
+    this possibility in the future. Also remember that a user may revoke access
+    via the Phraseanet settings page at any time.
 
 Sign Up
 -------

--- a/fr/Devel/API/V1/Authentification.rst
+++ b/fr/Devel/API/V1/Authentification.rst
@@ -30,7 +30,7 @@ Type de réponse d'authorisation supporté
   * token
   * code_and_token
 
-.. note:: À cet instant, le jeton d'authentification n'a pas de date d'expiration,
+.. note:: A cet instant, le jeton d'authentification n'a pas de date d'expiration,
     cependant, il faut être préparer à cette éventualité dans le futur.
     Ne pas oublier qu'un utilisateur peut révoquer l'accés à ses données via la page
     de configuration de Phraseanet à n'importe quel moment.


### PR DESCRIPTION
Add documentation on OAuth2.0 authentication using `password` grant type which is supported by Phraseanet API.

see http://tools.ietf.org/html/draft-ietf-oauth-v2-10#section-4.1.2
