### PR TITLE
Minor fixes 

### DIFF
--- a/en/Admin/Install.rst
+++ b/en/Admin/Install.rst
@@ -143,7 +143,7 @@ For a GUI installation, launch a browser and go to the root URL of the
 application. User is redirected to */setup/installer/* page.
 
 A set of screens containing forms helps to configure *Phraseaent* by collecting
-informations related to binaries and storage paths, admin account or databases
+information related to binaries and storage paths, admin account or databases
 connection parameters.
 
 Click on the **Next** button to start the procedure.

--- a/en/Admin/Plugins.rst
+++ b/en/Admin/Plugins.rst
@@ -136,7 +136,7 @@ dedicated autoloader.
 
 The file above declares that the plugin sources will be automatically loaded
 from the **src** directory and will follow a `PSR-0`_ structure.
-It is recommended to read `composer`_ documentation for more informations.
+It is recommended to read `composer`_ documentation for more information.
 
 Plugin authoring
 ----------------

--- a/en/Admin/Upgrade/3.8.rst
+++ b/en/Admin/Upgrade/3.8.rst
@@ -14,7 +14,7 @@ There is no more environment to declare and configuration is compiled in plain
 PHP to get the benefit of the `opcode cache`_.
 
 Configuration is automatically upgraded during the upgrade procedure. Detailed
-informations about the configuration are available in its
+information about the configuration are available in its
 :doc:`documentation<../Configuration>`.
 
 .. warning::

--- a/en/Devel/API/Changelog.rst
+++ b/en/Devel/API/Changelog.rst
@@ -18,7 +18,7 @@ caption...*etc*.).about a record in a single request.
 -----
 
 Version 1.4.0 of Phraseanet API is brought with Phraseanet 3.8.4.
-This upgrade is fully backward compatible, adds a new route to get informations
+This upgrade is fully backward compatible, adds a new route to get information
 about the current authenticated user.
 
 New routes

--- a/en/Devel/API/Root.rst
+++ b/en/Devel/API/Root.rst
@@ -4,15 +4,15 @@ Root
 About
 -----
 
-This route id available since Phraseanet 1.2 and provides  public informations
-about the API. This route is not versionned.
+Available since Phraseanet 1.2, this route provides public information
+about the Phraseanet API. This route is not versionned.
 
 .. code-block:: bash
 
     /api/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  NO

--- a/en/Devel/API/V1/Recommendation.rst
+++ b/en/Devel/API/V1/Recommendation.rst
@@ -6,7 +6,7 @@ Use HTTPS
 
 Since Phraseanet APIs does not provide any public endpoint, all requests need
 to be signed, it results in the transmission of plain text credentials in the
-HTTP request, to protect this sensitive informations, the authorization server
+HTTP request, to protect this sensitive information, the authorization server
 must require the use of a transport-layer security mechanism when sending
 requests to any Phraseanet API endpoints.
 

--- a/en/Devel/API/V1/Route/Baskets/Add.rst
+++ b/en/Devel/API/V1/Route/Baskets/Add.rst
@@ -4,14 +4,14 @@ Baskets Add
 About
 -----
 
-Adds a new basket
+Adds a new basket.
 
 .. code-block:: bash
 
     /api/v1/baskets/add/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Baskets/Content.rst
+++ b/en/Devel/API/V1/Route/Baskets/Content.rst
@@ -4,14 +4,14 @@ Baskets Content
 About
 -----
 
-Returns the content of the basket
+Returns the content of the basket.
 
 .. code-block:: bash
 
     /api/v1/baskets/{basket_id}/content/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Baskets/Delete.rst
+++ b/en/Devel/API/V1/Route/Baskets/Delete.rst
@@ -4,14 +4,14 @@ Baskets Delete
 About
 -----
 
-Delete the basket
+Deletes a given basket.
 
 .. code-block:: bash
 
     /api/v1/baskets/{basket_id}/delete/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              POST
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Baskets/List.rst
+++ b/en/Devel/API/V1/Route/Baskets/List.rst
@@ -4,14 +4,14 @@ Baskets List
 About
 -----
 
-Return the baskets list of the authenticated user
+Returns the baskets list of the authenticated user.
 
 .. code-block:: bash
 
     /api/v1/baskets/list/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes
@@ -20,7 +20,7 @@ Return the baskets list of the authenticated user
 Parameters
 ----------
 
-No parameters for this route
+There is no parameters for this route.
 
 Response Fields
 ---------------

--- a/en/Devel/API/V1/Route/Baskets/SetDescription.rst
+++ b/en/Devel/API/V1/Route/Baskets/SetDescription.rst
@@ -4,14 +4,14 @@ Baskets SetDescription
 About
 -----
 
-Set the description of the basket
+Sets a description to a given basket.
 
 .. code-block:: bash
 
     /api/v1/baskets/{basket_id}/setdescription/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              POST
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Baskets/SetName.rst
+++ b/en/Devel/API/V1/Route/Baskets/SetName.rst
@@ -4,14 +4,14 @@ Baskets SetName
 About
 -----
 
-Return
+Allows to update the name of a given basket.
 
 .. code-block:: bash
 
     /api/v1/baskets/{basket_id}/setname/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              POST
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Databox/Collections.rst
+++ b/en/Devel/API/V1/Route/Databox/Collections.rst
@@ -4,14 +4,14 @@ Databox Collections
 About
 -----
 
-Return available Collections on specified databox
+Returns available collections on a specified databox.
 
 .. code-block:: bash
 
     /api/v1/databoxes/{databox_id}/collections/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Databox/List.rst
+++ b/en/Devel/API/V1/Route/Databox/List.rst
@@ -4,14 +4,14 @@ Databox List
 About
 -----
 
-Return available Databoxes
+Returns available *databoxes*.
 
 .. code-block:: bash
 
     /api/v1/databoxes/list/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Databox/Metadatas.rst
+++ b/en/Devel/API/V1/Route/Databox/Metadatas.rst
@@ -4,14 +4,14 @@ Databox Metadatas
 About
 -----
 
-Return Metadatas settings on specified databox
+Returns Metadatas settings on a specified databox.
 
 .. code-block:: bash
 
     /api/v1/databoxes/{databox_id}/metadatas/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Databox/Status.rst
+++ b/en/Devel/API/V1/Route/Databox/Status.rst
@@ -1,17 +1,17 @@
 Databox Status
-===================
+==============
 
 About
 -----
 
-Return available Status on specified databox
+Returns available Phraseanet Status for a specified databox.
 
 .. code-block:: bash
 
     /api/v1/databoxes/{databox_id}/status/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Databox/TermsOfUse.rst
+++ b/en/Devel/API/V1/Route/Databox/TermsOfUse.rst
@@ -4,14 +4,14 @@ Databox TermsOfUse
 About
 -----
 
-Return Terms Of Use in all languages available on specified databox
+Returns *Terms Of Use* in all available languages for a specified databox.
 
 .. code-block:: bash
 
     /api/v1/databoxes/{databox_id}/termsOfUse/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Embed/Substitute.rst
+++ b/en/Devel/API/V1/Route/Embed/Substitute.rst
@@ -4,15 +4,15 @@ Embed Substitute
 About
 -----
 
-Substitute (or add) an embed file (subdef) to a record.
-Allows to inject an embed file built out from Phraseanet when a document has been added
-with the parameter "nosubdefs".
+Substitutes (or adds) an embed file (subdef) to a record.
+Allows to inject an embed file built out of Phraseanet when a document has been
+added with the parameter "nosubdefs".
 
 .. seealso:: :doc:`Add record <../Records/Add>`
 
 
 ========================== ======
- Informations
+ Information
 ========================== ======
  HTTP Method                POST
  Requires Authentication    Yes

--- a/en/Devel/API/V1/Route/Feeds/Aggregated.rst
+++ b/en/Devel/API/V1/Route/Feeds/Aggregated.rst
@@ -4,14 +4,14 @@ Feeds Aggregated Content
 About
 -----
 
-Return the aggregated content of a all feeds available
+Returns the aggregated content of specified feeds.
 
 .. code-block:: bash
 
     /api/v1/feeds/content/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes
@@ -25,7 +25,7 @@ Parameters
 ======================== ============== =================================
  offset_start             integer        The first entry to retrieve
  per_page                 integer        The number of entry to retrieve
- feeds                    array          An array of feed ids, aggregate will be on given ids
+ feeds                    array          An array of feeds ids, aggregate will be on given ids
 ======================== ============== =================================
 
 Response Fields

--- a/en/Devel/API/V1/Route/Feeds/Content.rst
+++ b/en/Devel/API/V1/Route/Feeds/Content.rst
@@ -4,14 +4,14 @@ Feed Content
 About
 -----
 
-Return the content of a feed
+Returns the content of a feed.
 
 .. code-block:: bash
 
     /api/v1/feeds/{feed_id}/content/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Feeds/Entry.rst
+++ b/en/Devel/API/V1/Route/Feeds/Entry.rst
@@ -4,14 +4,14 @@ Feeds Entry Content
 About
 -----
 
-Return the content of an entry, given an Id
+Returns the content of a selected entry.
 
 .. code-block:: bash
 
     /api/v1/feeds/entry/{entry_id}/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Feeds/List.rst
+++ b/en/Devel/API/V1/Route/Feeds/List.rst
@@ -4,14 +4,14 @@ Feeds List
 About
 -----
 
-List all available feeds
+Lists all available feeds.
 
 .. code-block:: bash
 
     /api/v1/feeds/list/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Me.rst
+++ b/en/Devel/API/V1/Route/Me.rst
@@ -11,7 +11,7 @@ Returns information about the authenticated user.
     /api/v1/me/
 
 ======================== ======
- Informations
+ Information
 ======================== ======
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Monitor/Phraseanet.rst
+++ b/en/Devel/API/V1/Route/Monitor/Phraseanet.rst
@@ -4,14 +4,14 @@ Phraseanet Monitor
 About
 -----
 
-Returns Phraseanet configuration for monitoring
+Returns Phraseanet configuration for monitoring.
 
 .. code-block:: bash
 
     /api/v1/monitor/phraseanet/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes
@@ -28,8 +28,8 @@ Response Fields
 =============== ======================================
  Field           Description
 =============== ======================================
- phraseanet      Phraseanet installation informations
- cache           The cache informations
+ phraseanet      Phraseanet installation information
+ cache           The cache information
  global_values   The configuration variables
 =============== ======================================
 

--- a/en/Devel/API/V1/Route/Monitor/Scheduler.rst
+++ b/en/Devel/API/V1/Route/Monitor/Scheduler.rst
@@ -4,14 +4,14 @@ Scheduler Monitor
 About
 -----
 
-Returns Scheduler informations for monitoring
+Returns Scheduler information for monitoring purposes.
 
 .. code-block:: bash
 
     /api/v1/monitor/scheduler/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes
@@ -28,7 +28,7 @@ Response Fields
 =============== ======================================
  Field           Description
 =============== ======================================
- scheduler       Scheduler informations
+ scheduler       Scheduler information
 =============== ======================================
 
 Response sample

--- a/en/Devel/API/V1/Route/Monitor/Task.rst
+++ b/en/Devel/API/V1/Route/Monitor/Task.rst
@@ -4,14 +4,14 @@ Task Monitor
 About
 -----
 
-Returns all informations about a task
+Returns all information about a given task.
 
 .. code-block:: bash
 
     /api/v1/monitor/task/{task_id}/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Monitor/TaskStart.rst
+++ b/en/Devel/API/V1/Route/Monitor/TaskStart.rst
@@ -4,14 +4,14 @@ Start a task
 About
 -----
 
-Start a task and return its status
+Starts a task and returns its state.
 
 .. code-block:: bash
 
     /api/v1/monitor/task/{task_id}/start/
 
 ======================== ======
- Informations
+ Information
 ======================== ======
  HTTP Method              POST
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Monitor/TaskStop.rst
+++ b/en/Devel/API/V1/Route/Monitor/TaskStop.rst
@@ -4,14 +4,14 @@ Stop a task
 About
 -----
 
-Stop a task and return its status
+Stops a task and returns its state.
 
 .. code-block:: bash
 
     /api/v1/monitor/task/{task_id}/stop/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              POST
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Monitor/Tasks.rst
+++ b/en/Devel/API/V1/Route/Monitor/Tasks.rst
@@ -4,14 +4,14 @@ Tasks monitor
 About
 -----
 
-Returns all information about all tasks
+Returns all information about available tasks.
 
 .. code-block:: bash
 
     /api/v1/monitor/tasks/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Quarantine/Item.rst
+++ b/en/Devel/API/V1/Route/Quarantine/Item.rst
@@ -4,14 +4,14 @@ Quarantine item
 About
 -----
 
-Return an item of the quarantine given its Id
+Returns an item of the quarantine given its Id.
 
 .. code-block:: bash
 
     /api/v1/quarantine/item/{quarantine_id}/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Quarantine/List.rst
+++ b/en/Devel/API/V1/Route/Quarantine/List.rst
@@ -4,14 +4,14 @@ Quarantine list
 About
 -----
 
-List the content of the quarantine
+Lists the content of the quarantine.
 
 .. code-block:: bash
 
     /api/v1/quarantine/list/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Records/Add.rst
+++ b/en/Devel/API/V1/Route/Records/Add.rst
@@ -13,7 +13,7 @@ it goes to the quarantine. This behavior can be bypassed with the optional
     /api/v1/records/add/
 
 ======================== ======
- Informations
+ Information
 ======================== ======
  HTTP Method              POST
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Records/Caption.rst
+++ b/en/Devel/API/V1/Route/Records/Caption.rst
@@ -4,14 +4,14 @@ Records Caption
 About
 -----
 
-Returns the caption of a record
+Returns the caption of a record.
 
 .. code-block:: bash
 
     /api/v1/records/{databox_id}/{record_id}/caption/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Records/Embed.rst
+++ b/en/Devel/API/V1/Route/Records/Embed.rst
@@ -36,7 +36,7 @@ HTTP HEAD requests are also supported by permalinks.
     /api/v1/records/{databox_id}/{record_id}/embed/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Records/Metadatas.rst
+++ b/en/Devel/API/V1/Route/Records/Metadatas.rst
@@ -4,14 +4,14 @@ Records Metadatas
 About
 -----
 
-Returns the metadatas of a record
+Returns the metadatas of a given record.
 
 .. code-block:: bash
 
     /api/v1/records/{databox_id}/{record_id}/metadatas/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Records/Record.rst
+++ b/en/Devel/API/V1/Route/Records/Record.rst
@@ -4,14 +4,14 @@ Records Record
 About
 -----
 
-Return all information about one record
+Returns all information about one record.
 
 .. code-block:: bash
 
     /api/v1/records/{databox_id}/{record_id}/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Records/Related.rst
+++ b/en/Devel/API/V1/Route/Records/Related.rst
@@ -4,14 +4,14 @@ Records Related
 About
 -----
 
-Return all baskets that contains one specific record
+Returns all baskets that contains a specified record.
 
 .. code-block:: bash
 
     /api/v1/records/{databox_id}/{record_id}/related/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Records/Search.rst
+++ b/en/Devel/API/V1/Route/Records/Search.rst
@@ -9,14 +9,14 @@ Records Search (deprecated)
 About
 -----
 
-Return the result of record search.
+Returns the result of a search query.
 
 .. code-block:: bash
 
     /api/v1/records/search/
 
 ======================== ======
- Informations
+ Information
 ======================== ======
  HTTP Method              POST
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Records/SetCollection.rst
+++ b/en/Devel/API/V1/Route/Records/SetCollection.rst
@@ -4,14 +4,14 @@ Records SetCollection
 About
 -----
 
-Moves a record to another collection
+Moves a record to another collection.
 
 .. code-block:: bash
 
     /api/v1/records/{databox_id}/{record_id}/setcollection/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              POST
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Records/SetMetadatas.rst
+++ b/en/Devel/API/V1/Route/Records/SetMetadatas.rst
@@ -4,14 +4,14 @@ Records SetMetadatas
 About
 -----
 
-Add, modify current record's metadatas
+Adds or modifies the metadatas for a given record.
 
 .. code-block:: bash
 
     /api/v1/records/{databox_id}/{record_id}/setmetadatas/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              POST
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Records/SetStatus.rst
+++ b/en/Devel/API/V1/Route/Records/SetStatus.rst
@@ -4,14 +4,14 @@ Records SetStatus
 About
 -----
 
-Set status to a record
+Sets status for a given record.
 
 .. code-block:: bash
 
     /api/v1/records/{databox_id}/{record_id}/setstatus/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              POST
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Records/Status.rst
+++ b/en/Devel/API/V1/Route/Records/Status.rst
@@ -4,14 +4,14 @@ Records Status
 About
 -----
 
-List all status of a record
+Lists all status of a given record.
 
 .. code-block:: bash
 
     /api/v1/records/{databox_id}/{record_id}/status/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Search.rst
+++ b/en/Devel/API/V1/Route/Search.rst
@@ -20,7 +20,7 @@ Whereas this route returns different types of records (documents, stories),
     /api/v1/search/
 
 ======================== ======
- Informations
+ Information
 ======================== ======
  HTTP Method              POST
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Stories/Add.rst
+++ b/en/Devel/API/V1/Route/Stories/Add.rst
@@ -4,14 +4,14 @@ Stories Add
 About
 -----
 
-Add stories
+Adds a new stories.
 
 .. code-block:: bash
 
     /api/v1/stories
 
 ======================== ==================
- Informations
+ Information
 ======================== ==================
  HTTP Method              POST
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Stories/AddRecords.rst
+++ b/en/Devel/API/V1/Route/Stories/AddRecords.rst
@@ -4,14 +4,14 @@ Stories AddRecords
 About
 -----
 
-Add records to a story
+Adds records to a given story.
 
 .. code-block:: bash
 
     /api/v1/stories/{databox_id}/{story_id}/addrecords
 
 ======================== ==================
- Informations
+ Information
 ======================== ==================
  HTTP Method              POST
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Stories/Embed.rst
+++ b/en/Devel/API/V1/Route/Stories/Embed.rst
@@ -11,7 +11,7 @@ Returns permalinks to medias attached to the story.
     /api/v1/stories/{databox_id}/{story_id}/embed/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Stories/SetCover.rst
+++ b/en/Devel/API/V1/Route/Stories/SetCover.rst
@@ -4,14 +4,14 @@ Stories SetCover
 About
 -----
 
-Set the cover of a story
+Sets the cover image of a given story.
 
 .. code-block:: bash
 
     /api/v1/stories/{databox_id}/{story_id}/setcover
 
 ======================== ==================
- Informations
+ Information
 ======================== ==================
  HTTP Method              POST
  Requires Authentication  Yes

--- a/en/Devel/API/V1/Route/Stories/Story.rst
+++ b/en/Devel/API/V1/Route/Stories/Story.rst
@@ -4,14 +4,14 @@ Stories Story
 About
 -----
 
-Return all information about one story
+Returns all information about a given story.
 
 .. code-block:: bash
 
     /api/v1/stories/{databox_id}/{story_id}/
 
 ======================== =====
- Informations
+ Information
 ======================== =====
  HTTP Method              GET
  Requires Authentication  Yes

--- a/en/User/Guide/Actions.rst
+++ b/en/User/Guide/Actions.rst
@@ -161,9 +161,9 @@ suggested tabs:
 * **Substitution**: Replace the original document by an other. A checkbox
   allows to choose if the thumbnail and the preview image have to be rebuilt.
 * **Substitution for subview**: Replace the thumbnail image by an other file.
-* **Metadatas**: Display all the metadatas informations read by the
-  **Exiftool** tool in the original media of the selected document (this tab is
-  available if only one document is selected)
+* **Metadatas**: Display all the metadatas information read by the
+  **Exiftool** application in the original media of the selected document (this
+  tab is available if only one document is selected)
 
 Delete
 ******

--- a/en/User/Guide/Customize.rst
+++ b/en/User/Guide/Customize.rst
@@ -48,7 +48,7 @@ In the **Display** tab, the user can:
 
 * Change the display mode from *Thumbnails* to *List*
 * Modify the colour set of the interface (Dark theme by default).
-* Change the informations displayed when mousing-over thumbnails by checking
+* Change the information displayed when mousing-over thumbnails by checking
   the Iconograph or Graphist mode
 * Choose to display the documents technical information in the Display area or
   in the detailed view

--- a/en/User/Guide/Display.rst
+++ b/en/User/Guide/Display.rst
@@ -88,7 +88,7 @@ By default, it is:
 
 **The "i" icon gives technical infos on the original document** : width
 and height in pixels, type, weight, printing size...
-In fact, displayed informations depend on media type.
+In fact, displayed information depend on media type.
 
 .. image:: ../../images/Affichage-i.jpg
     :align: center

--- a/en/User/Guide/Edit.rst
+++ b/en/User/Guide/Edit.rst
@@ -49,7 +49,7 @@ way as in the display area.
     Refer to :ref:`the section dedicated to selections <Display-Selections>`
     in the display area.
 
-Batch selections allows to write common informations for media to be more
+Batch selections allows to write common information for media to be more
 productive.
 
 To go from one field to an other, **use the Tab key of the keyboard**.

--- a/en/User/Guide/Publish.rst
+++ b/en/User/Guide/Publish.rst
@@ -90,7 +90,7 @@ In the **Bridge** window :
 .. image:: ../../images/Bridge-1b.jpg
     :align: center
 
-Bridge retrieves the existing informations from the remote application.
+Bridge retrieves the existing information from the remote application.
 
 With Flickr, the existing pictures are displayed in "Photos" tab or "Photosets"
 tab if organized in albums.

--- a/en/User/Guide/Push.rst
+++ b/en/User/Guide/Push.rst
@@ -86,7 +86,7 @@ To allow recipients to download original documents, two methods are available:
 * Click on the *Send* button to validate and transmit the Push.
 
 The following form is aimed to give a name and a description to the push. Those
-informations will part of the email notification addressed to recipients.
+information will part of the email notification addressed to recipients.
 If needed, an acknowledgement receipt of the email if this function is supported
 by the recipients mail boxes.
 

--- a/en/User/Guide/Stats.rst
+++ b/en/User/Guide/Stats.rst
@@ -9,7 +9,7 @@
     Statistics are available in Phraseanet. In Production, statistics
     on documents are available in a couple tabs in detailed view.
 
-    **Report** gives more detailed informations on the site's activity.
+    **Report** gives more detailed information on the site's activity.
 
 Statistics in Production
 ------------------------
@@ -35,7 +35,7 @@ Statistics in *Report*
 ----------------------
 
 Report regroups the statistics on connections, downloads, and site activity.
-A dashboard sums up these main informations.
+A dashboard sums up these main information.
 
 **To start a Report**, click on the corresponding section in the menu bar then
 generate the report for a chosen period.

--- a/en/User/Guide/Thesaurus.rst
+++ b/en/User/Guide/Thesaurus.rst
@@ -7,8 +7,8 @@ Thesaurus
 .. topic:: The essential
 
     Thesaurus is a documentary language management tool. In Phraseanet, its
-    implementation is optional. It is used with the Phrasea engine and is not
-    compatible with the Sphinx search engine.
+    implementation is optional. It can be used with the Phrasea engine only (not
+    compatible with the Sphinx search engine).
 
     In Production, the thesaurus serves :
 
@@ -254,8 +254,8 @@ Working on candidates
 ---------------------
 
 Candidates are terms and expressions linked to branches of the thesaurus but
-are not part of it. These terms can either come from informations extracted
-from metadata of added files, or from informations added while capturing
+are not part of it. These terms can either come from information extracted
+from metadata of added files, or from information added while capturing
 records notes.
 
 A part of the maintenance of thesaurus consists in examining these candidates.

--- a/fr/Devel/API/V1/Route/Monitor/Task.rst
+++ b/fr/Devel/API/V1/Route/Monitor/Task.rst
@@ -4,7 +4,7 @@ Monitorer les tâches de Phraseanet
 A propos
 --------
 
-Returns all informations A propos a task
+Retourne des informations sur une tâche.
 
 .. code-block:: bash
 


### PR DESCRIPTION
- Removes / replaces the misspelled word Informations with Information in english manual (except in API response examples) as it's never plurial

- Conjugated verbs in sentences of the About paragraphs in the english API manual pages